### PR TITLE
feat(cli): add short single-dash aliases for options and bump to v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,24 +69,26 @@ Usage: KrakenParser [OPTIONS] COMMAND [ARGS]...
  to see options for a specific step.                                            
                                                                                 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --input       -i      PATH     Directory containing Kraken2 report files.    │
-│ --output      -o      PATH     Output directory.                             │
-│ --viruses                      Extract only VIRUSES domain taxa in the       │
-│                                pipeline.                                     │
-│ --bacteria                     Extract only BACTERIA domain taxa in the      │
-│                                pipeline.                                     │
-│ --fungi                        Extract only FUNGI kingdom taxa in the        │
-│                                pipeline.                                     │
-│ --archaea                      Extract only ARCHAEA domain taxa in the       │
-│                                pipeline.                                     │
-│ --keep-human                   Do not filter human-related taxa.             │
-│ --version     -V               Show version and exit.                        │
-│ --depth       -d      INTEGER  Rarefaction depth for β-diversity.            │
-│                                [default: 1000]                               │
-│ --seed        -s      INTEGER  Random seed for reproducible rarefaction.     │
-│ --overwrite                    Overwrite the output directory if it already  │
-│                                exists.                                       │
-│ --help        -h               Show this message and exit.                   │
+│ --input       -i               PATH     Directory containing Kraken2 report  │
+│                                         files.                               │
+│ --output      -o               PATH     Output directory.                    │
+│ --viruses     -viruses                  Extract only VIRUSES domain taxa in  │
+│                                         the pipeline.                        │
+│ --bacteria    -bacteria                 Extract only BACTERIA domain taxa in │
+│                                         the pipeline.                        │
+│ --fungi       -fungi                    Extract only FUNGI kingdom taxa in   │
+│                                         the pipeline.                        │
+│ --archaea     -archaea                  Extract only ARCHAEA domain taxa in  │
+│                                         the pipeline.                        │
+│ --keep-human  -keep-human               Do not filter human-related taxa.    │
+│ --version     -V                        Show version and exit.               │
+│ --depth       -d               INTEGER  Rarefaction depth for β-diversity.   │
+│                                         [default: 1000]                      │
+│ --seed        -s               INTEGER  Random seed for reproducible         │
+│                                         rarefaction.                         │
+│ --overwrite   -overwrite                Overwrite the output directory if it │
+│                                         already exists.                      │
+│ --help        -h                        Show this message and exit.          │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Advanced (Step-by-step pipeline control) ───────────────────────────────────╮
 │ mpa        Convert a Kraken2 report to MetaPhlAn (MPA) format.               │
@@ -319,7 +321,7 @@ results/
 │     ├─ counts_genus.txt
 │     ├─ ...
 │     └─ counts_phylum.txt
-└─ krakenparser.log         # Pipeline execution logs
+└─ krakenparser.log        # Pipeline execution logs
 ```
 
 ## Conclusion

--- a/krakenparser/krakenparser.py
+++ b/krakenparser/krakenparser.py
@@ -60,19 +60,31 @@ def main_callback(
         None, "-o", "--output", help="Output directory."
     ),
     viruses: bool = typer.Option(
-        False, "--viruses", help="Extract only VIRUSES domain taxa in the pipeline."
+        False,
+        "-viruses",
+        "--viruses",
+        help="Extract only VIRUSES domain taxa in the pipeline.",
     ),
     bacteria: bool = typer.Option(
-        False, "--bacteria", help="Extract only BACTERIA domain taxa in the pipeline."
+        False,
+        "-bacteria",
+        "--bacteria",
+        help="Extract only BACTERIA domain taxa in the pipeline.",
     ),
     fungi: bool = typer.Option(
-        False, "--fungi", help="Extract only FUNGI kingdom taxa in the pipeline."
+        False,
+        "-fungi",
+        "--fungi",
+        help="Extract only FUNGI kingdom taxa in the pipeline.",
     ),
     archaea: bool = typer.Option(
-        False, "--archaea", help="Extract only ARCHAEA domain taxa in the pipeline."
+        False,
+        "-archaea",
+        "--archaea",
+        help="Extract only ARCHAEA domain taxa in the pipeline.",
     ),
     keep_human: bool = typer.Option(
-        False, "--keep-human", help="Do not filter human-related taxa."
+        False, "-keep-human", "--keep-human", help="Do not filter human-related taxa."
     ),
     version: Optional[bool] = typer.Option(
         None,
@@ -90,6 +102,7 @@ def main_callback(
     ),
     overwrite: bool = typer.Option(
         False,
+        "-overwrite",
         "--overwrite",
         help="Overwrite the output directory if it already exists.",
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "krakenparser"
-version = "1.1.0"
+version = "1.1.1"
 description = "A collection of scripts designed to process Kraken2 reports and convert them into CSV format."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}


### PR DESCRIPTION
### Summary
Added alternative single-dash aliases for several CLI flags to improve user convenience, updated the documentation, and bumped the project version to `1.1.1`.

### Changes
* **Code (`krakenparser/krakenparser.py`):** Added single-dash aliases (`-viruses`, `-bacteria`, `-fungi`, `-archaea`, `-keep-human`, `-overwrite`) to existing options.
* **Documentation (`README.md`):** Updated the CLI help output section to reflect the new flags; fixed minor trailing whitespace.
* **Configuration (`pyproject.toml`):** Bumped package version from `1.1.0` to `1.1.1`.